### PR TITLE
Fix - Widen components for WordPress specific sizing paramaters

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@ body {
 }
 
 #settings {
-  width: 50%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 1em;
@@ -42,7 +42,7 @@ body {
 }
 
 #spotify {
-  width: 40%;
+  width: 100%;
 }
 
 @keyframes breatheInAnimation {


### PR DESCRIPTION
Wordpress layout contains different width parameters than than local dev env. This fix allows the page components to take up more space, as they were becoming too small and/or cut-off with the last update.

Hotfix:

- Widen the Spotify player to sit more neatly within the Wordpress container.
- Widen the "settings" container for the same purpose.