### PR TITLE
Add Mobile View

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <div id="settings">
       <!-- Dropdown for customizing the length of time -->
-      <div class="centered">
+      <div class="centered settings-container">
         <label for="duration">Select duration (in minutes): </label>
         <select id="duration-select" class="form-select form-select-sm">
             <option value="5">5</option>
@@ -25,7 +25,7 @@
       </div>
 
       <!-- Dropdown for customizing the duration between chimes -->
-      <div class="centered">
+      <div class="centered settings-container">
         <label for="interval">Select interval duration (in seconds): </label>
         <select id="interval-select" class="form-select form-select-sm">
             <option value="6">6</option>

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,10 @@ body {
   gap: 1em;
 }
 
+select {
+  min-width: fit-content;
+}
+
 .centered {
   display: flex;
   justify-content: center;
@@ -62,3 +66,16 @@ body {
 .exhale {
   animation: breatheOutAnimation 4s forwards;
 }
+
+@media (max-width: 550px) {
+  .settings-container {
+    flex-direction: column;
+    align-items: center;
+    gap: 1em;
+  }
+}
+
+/* Media query reserved for the smallest possible screens */
+/* @media (max-width: 265px) {
+
+} */


### PR DESCRIPTION
A few small updates to make the timer responsive to smaller screen sizes, specifically screens less than 550px in width. On larger screens the layout will remain the same.

**BEFORE**
Dropdown duration selectors had their contents cut off and were squished awkwardly beside their labels.

<img width="349" alt="Screenshot 2024-03-25 at 21 25 48" src="https://github.com/agmcdonald24/breathepgh/assets/95148403/e541ea85-ef5b-43aa-8fca-ece7f9a17301">


**AFTER**
Gave dropdown duration selectors a minimum width and placed them below their labels.

<img width="351" alt="Screenshot 2024-03-25 at 21 24 17" src="https://github.com/agmcdonald24/breathepgh/assets/95148403/fbc80d68-035b-4eb6-bc45-d03b8770b3bd">
